### PR TITLE
Update edd_get_product_to_duplicate return values

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -1,43 +1,76 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Duplicate a product link on products list
  */
-function edd_duplicate_product_link_row($actions, $post) {
-	if (!($post->post_type=='download')) return $actions;
+function edd_duplicate_product_link_row( $actions, $post ) {
+	if ( 'download' !== $post->post_type ) {
+		return $actions;
+	}
 
-	$actions['duplicate'] = '<a href="' . wp_nonce_url( admin_url( 'admin.php?action=duplicate_product&amp;post=' . $post->ID ), 'edd-duplicate-product_' . $post->ID ) . '" title="' . __("Make a duplicate from this product", 'edd')
-		. '" rel="permalink">' .  __("Duplicate", 'edd') . '</a>';
+	$actions['duplicate'] = sprintf(
+		'<a href="%s" rel="permalink">%s</a>',
+		esc_url( edd_duplicate_product_get_duplicate_url( $post->ID ) ),
+		__( 'Duplicate', 'edd' )
+	);
 
 	return $actions;
 }
-add_filter('post_row_actions', 'edd_duplicate_product_link_row',10,2);
-add_filter('page_row_actions', 'edd_duplicate_product_link_row',10,2);
+add_filter( 'post_row_actions', 'edd_duplicate_product_link_row', 10, 2 );
+add_filter( 'page_row_actions', 'edd_duplicate_product_link_row', 10, 2 );
 
 /**
  *  Duplicate a product link on edit screen
  */
 function edd_duplicate_product_post_button() {
 	global $post;
-	
-	if (function_exists('duplicate_post_plugin_activation')) return;
 
-	if( !is_object( $post ) ) return;
+	if ( function_exists( 'duplicate_post_plugin_activation' ) ) {
+		return;
+	}
 
-	if ($post->post_type!='download') return;
+	if ( ! is_object( $post ) ) {
+		return;
+	}
 
-	if ( isset( $_GET['post'] ) ) :
-		$notifyUrl = wp_nonce_url( admin_url( "admin.php?action=duplicate_product&post=" . $_GET['post'] ), 'edd-duplicate-product_' . $_GET['post'] );
-		?>
-		<div id="duplicate-action"><a class="submitduplicate duplication" href="<?php echo esc_url( $notifyUrl ); ?>"><?php _e('Duplicate Me!', 'edd'); ?></a></div>
-		<?php
-	endif;
+	if ( 'download' !== $post->post_type ) {
+		return;
+	}
+
+	?>
+	<div id="duplicate-action"><a class="submitduplicate duplication" href="<?php echo esc_url( edd_duplicate_product_get_duplicate_url( $post->ID ) ); ?>"><?php esc_html_e( 'Duplicate Me!', 'edd' ); ?></a></div>
+	<?php
 }
 add_action( 'post_submitbox_start', 'edd_duplicate_product_post_button' );
 
 function edd_duplicate_product_action() {
-	require_once(dirname(__FILE__).'/duplicate.php');
+	require_once dirname( __FILE__ ) . '/duplicate.php';
 	edd_duplicate_product();
 }
-add_action('admin_action_duplicate_product', 'edd_duplicate_product_action');
+add_action( 'admin_action_duplicate_product', 'edd_duplicate_product_action' );
+
+/**
+ * Gets the URL to duplicate a download.
+ *
+ * @param int $post_id
+ * @return string
+ */
+function edd_duplicate_product_get_duplicate_url( $post_id ) {
+
+	$post_id = (int) $post_id;
+
+	return wp_nonce_url(
+		add_query_arg(
+			array(
+				'action' => 'duplicate_product',
+				'post'   => urlencode( $post_id ),
+			),
+			admin_url( 'admin.php' )
+		),
+		"edd-duplicate-product_{$post_id}"
+	);
+}

--- a/duplicate.php
+++ b/duplicate.php
@@ -2,12 +2,17 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function edd_duplicate_product() {
-	if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] )  || ( isset( $_REQUEST['action'] ) && 'duplicate_post_save_as_new_page' == $_REQUEST['action'] ) ) ) {
+
+	// Get the original product
+	$id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+	if ( empty( $id ) ) {
+		$id = filter_input( INPUT_POST, 'post', FILTER_SANITIZE_NUMBER_INT );
+	}
+
+	if ( empty( $id ) || ( isset( $_REQUEST['action'] ) && 'duplicate_post_save_as_new_page' === $_REQUEST['action'] ) ) {
 		wp_die( __( 'No product to duplicate has been supplied!', 'edd' ) );
 	}
 
-	// Get the original product
-	$id = ( isset( $_GET['post'] ) ? $_GET['post'] : $_POST['post'] );
 	check_admin_referer( 'edd-duplicate-product_' . $id );
 	$post = edd_get_product_to_duplicate( $id );
 
@@ -18,7 +23,7 @@ function edd_duplicate_product() {
 		do_action( 'edd_duplicate_product', $new_id, $post );
 
 		// Redirect to the edit screen for the new draft page
-		wp_redirect( admin_url( 'post.php?action=edit&post=' . $new_id ) );
+		wp_safe_redirect( admin_url( 'post.php?action=edit&post=' . $new_id ) );
 		exit;
 	} else {
 		wp_die( __( 'Product creation failed, could not find original product:', 'edd' ) . ' ' . $id );
@@ -34,12 +39,13 @@ function edd_duplicate_product() {
 function edd_get_product_to_duplicate( $id ) {
 	global $wpdb;
 
-	$post = $wpdb->get_results( "SELECT * FROM $wpdb->posts WHERE ID=$id" );
-	if ( isset( $post->post_type ) && $post->post_type == "revision" ) {
+	$post = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->posts} WHERE ID = %d", $id ) );
+	if ( isset( $post->post_type ) && 'revision' === $post->post_type ) {
 		$id   = $post->post_parent;
-		$post = $wpdb->get_results( "SELECT * FROM $wpdb->posts WHERE ID=$id" );
+		$post = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->posts} WHERE ID = %d", $id ) );
 	}
-	return is_array( $post ) ? reset( $post ) : null;
+
+	return $post;
 }
 
 /**
@@ -73,10 +79,32 @@ function edd_create_duplicate_from_product( $post, $parent = 0, $post_status = '
 
 	// Insert the new template in the post table
 	$wpdb->query(
-			"INSERT INTO $wpdb->posts
+		$wpdb->prepare(
+			"INSERT INTO {$wpdb->posts}
 			(post_author, post_date, post_date_gmt, post_content, post_content_filtered, post_title, post_excerpt,  post_status, post_type, comment_status, ping_status, post_password, to_ping, pinged, post_modified, post_modified_gmt, post_parent, menu_order, post_mime_type)
 			VALUES
-			('$new_post_author->ID', '$new_post_date', '$new_post_date_gmt', '$post_content', '$post_content_filtered', '$post_title', '$post_excerpt', '$post_status', '$new_post_type', '$comment_status', '$ping_status', '$post->post_password', '$post->to_ping', '$post->pinged', '$new_post_date', '$new_post_date_gmt', '$post_parent', '$post->menu_order', '$post->post_mime_type')");
+			(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+			$new_post_author->ID,
+			$new_post_date,
+			$new_post_date_gmt,
+			$post_content,
+			$post_content_filtered,
+			$post_title,
+			$post_excerpt,
+			$post_status,
+			$new_post_type,
+			$comment_status,
+			$ping_status,
+			$post->post_password,
+			$post->to_ping,
+			$post->pinged,
+			$new_post_date,
+			$new_post_date_gmt,
+			$post_parent,
+			$post->menu_order,
+			$post->post_mime_type
+		)
+	);
 
 	$new_post_id = $wpdb->insert_id;
 
@@ -101,7 +129,7 @@ function edd_duplicate_post_taxonomies( $id, $new_id, $post_type ) {
 	foreach ($taxonomies as $taxonomy) {
 
 		$post_terms       = wp_get_object_terms( $id, $taxonomy );
-		$post_terms_count = sizeof( $post_terms );
+		$post_terms_count = count( $post_terms );
 
 		for ( $i=0; $i<$post_terms_count; $i++ ) {
 			wp_set_object_terms( $new_id, $post_terms[ $i ]->slug, $taxonomy, true );
@@ -112,19 +140,26 @@ function edd_duplicate_post_taxonomies( $id, $new_id, $post_type ) {
 
 /**
  * Copy the meta information of a Product to another Product
+ *
+ * @param int $id     The original download ID.
+ * @param int $new_id The new download ID.
  */
-function edd_duplicate_post_meta($id, $new_id) {
+function edd_duplicate_post_meta( $id, $new_id ) {
 	global $wpdb;
-	$post_meta_infos = $wpdb->get_results("SELECT meta_key, meta_value FROM $wpdb->postmeta WHERE post_id=$id");
+	$post_meta_infos = $wpdb->get_results( $wpdb->prepare( "SELECT meta_key, meta_value FROM {$wpdb->postmeta} WHERE post_id = %d", $id ) );
 
-	if (count($post_meta_infos)!=0) {
-		$sql_query = "INSERT INTO $wpdb->postmeta (post_id, meta_key, meta_value) ";
-		foreach ($post_meta_infos as $meta_info) {
-			$meta_key = $meta_info->meta_key;
-			$meta_value = addslashes($meta_info->meta_value);
-			$sql_query_sel[]= "SELECT $new_id, '$meta_key', '$meta_value'";
+	if ( count( $post_meta_infos ) ) {
+		$sql_query     = "INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value) ";
+		$sql_query_sel = array();
+		foreach ( $post_meta_infos as $meta_info ) {
+			$sql_query_sel[] = $wpdb->prepare(
+				"SELECT %d, %s, %s",
+				$new_id,
+				$meta_info->meta_key,
+				$meta_info->meta_value
+			);
 		}
-		$sql_query.= implode(" UNION ALL ", $sql_query_sel);
-		$wpdb->query($sql_query);
+		$sql_query .= implode( " UNION ALL ", $sql_query_sel );
+		$wpdb->query( $sql_query );
 	}
 }


### PR DESCRIPTION
Fixes #12

Proposed changes:
1. If the SQL query in `edd_get_product_to_duplicate` does not return an array of posts (not WP_Post objects), return `null`.
2. Remove child product logic from `edd_create_duplicate_from_product` because EDD doesn't have a `product_variation` post type.