### PR TITLE
Use edd_duplicate_product directly for admin_action

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -58,7 +58,6 @@ function edd_duplicate_product_action() {
 	require_once dirname( __FILE__ ) . '/duplicate.php';
 	edd_duplicate_product();
 }
-add_action( 'admin_action_duplicate_product', 'edd_duplicate_product' );
 
 /**
  * Gets the URL to duplicate a download.

--- a/admin.php
+++ b/admin.php
@@ -47,11 +47,17 @@ function edd_duplicate_product_post_button() {
 }
 add_action( 'post_submitbox_start', 'edd_duplicate_product_post_button' );
 
+/**
+ * Includes the duplicate.php file and runs edd_duplicate_product.
+ *
+ * @deprecated 1.0.2 because the require_once is not needed.
+ * @return void
+ */
 function edd_duplicate_product_action() {
 	require_once dirname( __FILE__ ) . '/duplicate.php';
 	edd_duplicate_product();
 }
-add_action( 'admin_action_duplicate_product', 'edd_duplicate_product_action' );
+add_action( 'admin_action_duplicate_product', 'edd_duplicate_product' );
 
 /**
  * Gets the URL to duplicate a download.

--- a/admin.php
+++ b/admin.php
@@ -54,6 +54,7 @@ add_action( 'post_submitbox_start', 'edd_duplicate_product_post_button' );
  * @return void
  */
 function edd_duplicate_product_action() {
+	_deprecated_function( __FUNCTION__, '1.0.2', 'edd_duplicate_product' );
 	require_once dirname( __FILE__ ) . '/duplicate.php';
 	edd_duplicate_product();
 }

--- a/duplicate.php
+++ b/duplicate.php
@@ -29,6 +29,7 @@ function edd_duplicate_product() {
 		wp_die( __( 'Product creation failed, could not find original product:', 'edd' ) . ' ' . $id );
 	}
 }
+add_action( 'admin_action_duplicate_product', 'edd_duplicate_product' );
 
 /**
  * Gets a product from the database.


### PR DESCRIPTION
Fixes #13 

Because the `admin_action_duplicate_product` now calls edd_duplicate_product` directly, I updated the doc block to indicate that is deprecated, and a call to `_deprecated_function()`.