### PR TITLE
Release/1.0.2

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -15,7 +15,7 @@ function edd_duplicate_product_link_row( $actions, $post ) {
 	$actions['duplicate'] = sprintf(
 		'<a href="%s" rel="permalink">%s</a>',
 		esc_url( edd_duplicate_product_get_duplicate_url( $post->ID ) ),
-		__( 'Duplicate', 'edd' )
+		__( 'Duplicate', 'edd-duplicate-downloads' )
 	);
 
 	return $actions;
@@ -42,7 +42,7 @@ function edd_duplicate_product_post_button() {
 	}
 
 	?>
-	<div id="duplicate-action"><a class="submitduplicate duplication" href="<?php echo esc_url( edd_duplicate_product_get_duplicate_url( $post->ID ) ); ?>"><?php esc_html_e( 'Duplicate Me!', 'edd' ); ?></a></div>
+	<div id="duplicate-action"><a class="submitduplicate duplication" href="<?php echo esc_url( edd_duplicate_product_get_duplicate_url( $post->ID ) ); ?>"><?php esc_html_e( 'Duplicate Me!', 'edd-duplicate-downloads' ); ?></a></div>
 	<?php
 }
 add_action( 'post_submitbox_start', 'edd_duplicate_product_post_button' );

--- a/admin.php
+++ b/admin.php
@@ -1,43 +1,76 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Duplicate a product link on products list
  */
-function edd_duplicate_product_link_row($actions, $post) {
-	if (!($post->post_type=='download')) return $actions;
+function edd_duplicate_product_link_row( $actions, $post ) {
+	if ( 'download' !== $post->post_type ) {
+		return $actions;
+	}
 
-	$actions['duplicate'] = '<a href="' . wp_nonce_url( admin_url( 'admin.php?action=duplicate_product&amp;post=' . $post->ID ), 'edd-duplicate-product_' . $post->ID ) . '" title="' . __("Make a duplicate from this product", 'edd')
-		. '" rel="permalink">' .  __("Duplicate", 'edd') . '</a>';
+	$actions['duplicate'] = sprintf(
+		'<a href="%s" rel="permalink">%s</a>',
+		esc_url( edd_duplicate_product_get_duplicate_url( $post->ID ) ),
+		__( 'Duplicate', 'edd' )
+	);
 
 	return $actions;
 }
-add_filter('post_row_actions', 'edd_duplicate_product_link_row',10,2);
-add_filter('page_row_actions', 'edd_duplicate_product_link_row',10,2);
+add_filter( 'post_row_actions', 'edd_duplicate_product_link_row', 10, 2 );
+add_filter( 'page_row_actions', 'edd_duplicate_product_link_row', 10, 2 );
 
 /**
  *  Duplicate a product link on edit screen
  */
 function edd_duplicate_product_post_button() {
 	global $post;
-	
-	if (function_exists('duplicate_post_plugin_activation')) return;
 
-	if( !is_object( $post ) ) return;
+	if ( function_exists( 'duplicate_post_plugin_activation' ) ) {
+		return;
+	}
 
-	if ($post->post_type!='download') return;
+	if ( ! is_object( $post ) ) {
+		return;
+	}
 
-	if ( isset( $_GET['post'] ) ) :
-		$notifyUrl = wp_nonce_url( admin_url( "admin.php?action=duplicate_product&post=" . $_GET['post'] ), 'edd-duplicate-product_' . $_GET['post'] );
-		?>
-		<div id="duplicate-action"><a class="submitduplicate duplication" href="<?php echo esc_url( $notifyUrl ); ?>"><?php _e('Duplicate Me!', 'edd'); ?></a></div>
-		<?php
-	endif;
+	if ( 'download' !== $post->post_type ) {
+		return;
+	}
+
+	?>
+	<div id="duplicate-action"><a class="submitduplicate duplication" href="<?php echo esc_url( edd_duplicate_product_get_duplicate_url( $post->ID ) ); ?>"><?php esc_html_e( 'Duplicate Me!', 'edd' ); ?></a></div>
+	<?php
 }
 add_action( 'post_submitbox_start', 'edd_duplicate_product_post_button' );
 
 function edd_duplicate_product_action() {
-	require_once(dirname(__FILE__).'/duplicate.php');
+	require_once dirname( __FILE__ ) . '/duplicate.php';
 	edd_duplicate_product();
 }
-add_action('admin_action_duplicate_product', 'edd_duplicate_product_action');
+add_action( 'admin_action_duplicate_product', 'edd_duplicate_product_action' );
+
+/**
+ * Gets the URL to duplicate a download.
+ *
+ * @param int $post_id
+ * @return string
+ */
+function edd_duplicate_product_get_duplicate_url( $post_id ) {
+
+	$post_id = (int) $post_id;
+
+	return wp_nonce_url(
+		add_query_arg(
+			array(
+				'action' => 'duplicate_product',
+				'post'   => urlencode( $post_id ),
+			),
+			admin_url( 'admin.php' )
+		),
+		"edd-duplicate-product_{$post_id}"
+	);
+}

--- a/admin.php
+++ b/admin.php
@@ -47,11 +47,17 @@ function edd_duplicate_product_post_button() {
 }
 add_action( 'post_submitbox_start', 'edd_duplicate_product_post_button' );
 
+/**
+ * Includes the duplicate.php file and runs edd_duplicate_product.
+ *
+ * @deprecated 1.0.2 because the require_once is not needed.
+ * @return void
+ */
 function edd_duplicate_product_action() {
+	_deprecated_function( __FUNCTION__, '1.0.2', 'edd_duplicate_product' );
 	require_once dirname( __FILE__ ) . '/duplicate.php';
 	edd_duplicate_product();
 }
-add_action( 'admin_action_duplicate_product', 'edd_duplicate_product_action' );
 
 /**
  * Gets the URL to duplicate a download.

--- a/duplicate.php
+++ b/duplicate.php
@@ -2,23 +2,28 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function edd_duplicate_product() {
-	if ( ! ( isset( $_GET['post'] ) || isset( $_POST['post'] )  || ( isset( $_REQUEST['action'] ) && 'duplicate_post_save_as_new_page' == $_REQUEST['action'] ) ) ) {
+
+	// Get the original product
+	$id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+	if ( empty( $id ) ) {
+		$id = filter_input( INPUT_POST, 'post', FILTER_SANITIZE_NUMBER_INT );
+	}
+
+	if ( empty( $id ) || ( isset( $_REQUEST['action'] ) && 'duplicate_post_save_as_new_page' === $_REQUEST['action'] ) ) {
 		wp_die( __( 'No product to duplicate has been supplied!', 'edd' ) );
 	}
 
-	// Get the original product
-	$id = ( isset( $_GET['post'] ) ? $_GET['post'] : $_POST['post'] );
 	check_admin_referer( 'edd-duplicate-product_' . $id );
 	$post = edd_get_product_to_duplicate( $id );
 
 	// Copy the product
-	if ( isset( $post ) && $post != null ) {
+	if ( null !== $post ) {
 		$new_id = edd_create_duplicate_from_product( $post );
 
 		do_action( 'edd_duplicate_product', $new_id, $post );
 
 		// Redirect to the edit screen for the new draft page
-		wp_redirect( admin_url( 'post.php?action=edit&post=' . $new_id ) );
+		wp_safe_redirect( admin_url( 'post.php?action=edit&post=' . $new_id ) );
 		exit;
 	} else {
 		wp_die( __( 'Product creation failed, could not find original product:', 'edd' ) . ' ' . $id );
@@ -26,17 +31,21 @@ function edd_duplicate_product() {
 }
 
 /**
- * Get a product from the database
+ * Gets a product from the database.
+ *
+ * @param int|string $id The ID of the download to duplicate.
+ * @return object|null Returns an object if a download is found; otherwise null.
  */
-function edd_get_product_to_duplicate($id) {
+function edd_get_product_to_duplicate( $id ) {
 	global $wpdb;
 
-	$post = $wpdb->get_results( "SELECT * FROM $wpdb->posts WHERE ID=$id" );
-	if ( isset( $post->post_type ) && $post->post_type == "revision" ){
+	$post = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->posts} WHERE ID = %d", $id ) );
+	if ( isset( $post->post_type ) && 'revision' === $post->post_type ) {
 		$id   = $post->post_parent;
-		$post = $wpdb->get_results( "SELECT * FROM $wpdb->posts WHERE ID=$id" );
+		$post = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->posts} WHERE ID = %d", $id ) );
 	}
-	return $post[0];
+
+	return $post;
 }
 
 /**
@@ -48,7 +57,7 @@ function edd_create_duplicate_from_product( $post, $parent = 0, $post_status = '
 	$new_post_author   = wp_get_current_user();
 	$new_post_date     = current_time( 'mysql' );
 	$new_post_date_gmt = get_gmt_from_date( $new_post_date );
-	
+
 	if ( $parent > 0 ) {
 		$post_parent = $parent;
 		$post_status = $post_status ? $post_status : 'publish';
@@ -70,10 +79,32 @@ function edd_create_duplicate_from_product( $post, $parent = 0, $post_status = '
 
 	// Insert the new template in the post table
 	$wpdb->query(
-			"INSERT INTO $wpdb->posts
+		$wpdb->prepare(
+			"INSERT INTO {$wpdb->posts}
 			(post_author, post_date, post_date_gmt, post_content, post_content_filtered, post_title, post_excerpt,  post_status, post_type, comment_status, ping_status, post_password, to_ping, pinged, post_modified, post_modified_gmt, post_parent, menu_order, post_mime_type)
 			VALUES
-			('$new_post_author->ID', '$new_post_date', '$new_post_date_gmt', '$post_content', '$post_content_filtered', '$post_title', '$post_excerpt', '$post_status', '$new_post_type', '$comment_status', '$ping_status', '$post->post_password', '$post->to_ping', '$post->pinged', '$new_post_date', '$new_post_date_gmt', '$post_parent', '$post->menu_order', '$post->post_mime_type')");
+			(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+			$new_post_author->ID,
+			$new_post_date,
+			$new_post_date_gmt,
+			$post_content,
+			$post_content_filtered,
+			$post_title,
+			$post_excerpt,
+			$post_status,
+			$new_post_type,
+			$comment_status,
+			$ping_status,
+			$post->post_password,
+			$post->to_ping,
+			$post->pinged,
+			$new_post_date,
+			$new_post_date_gmt,
+			$post_parent,
+			$post->menu_order,
+			$post->post_mime_type
+		)
+	);
 
 	$new_post_id = $wpdb->insert_id;
 
@@ -87,15 +118,6 @@ function edd_create_duplicate_from_product( $post, $parent = 0, $post_status = '
 	update_post_meta( $new_post_id, '_edd_download_earnings', '0.00' );
 	update_post_meta( $new_post_id, '_edd_download_sales', '0' );
 
-	// Copy the children (variations)
-	if ( $children_products = get_children( 'post_parent=' . $post->ID . '&post_type=product_variation' ) ) {
-		if ( $children_products ) {
-			foreach ( $children_products as $child ) {
-				edd_create_duplicate_from_product( edd_get_product_to_duplicate( $child->ID ), $new_post_id, $child->post_status );
-			}
-		}
-	}
-
 	return $new_post_id;
 }
 
@@ -107,7 +129,7 @@ function edd_duplicate_post_taxonomies( $id, $new_id, $post_type ) {
 	foreach ($taxonomies as $taxonomy) {
 
 		$post_terms       = wp_get_object_terms( $id, $taxonomy );
-		$post_terms_count = sizeof( $post_terms );
+		$post_terms_count = count( $post_terms );
 
 		for ( $i=0; $i<$post_terms_count; $i++ ) {
 			wp_set_object_terms( $new_id, $post_terms[ $i ]->slug, $taxonomy, true );
@@ -118,19 +140,26 @@ function edd_duplicate_post_taxonomies( $id, $new_id, $post_type ) {
 
 /**
  * Copy the meta information of a Product to another Product
+ *
+ * @param int $id     The original download ID.
+ * @param int $new_id The new download ID.
  */
-function edd_duplicate_post_meta($id, $new_id) {
+function edd_duplicate_post_meta( $id, $new_id ) {
 	global $wpdb;
-	$post_meta_infos = $wpdb->get_results("SELECT meta_key, meta_value FROM $wpdb->postmeta WHERE post_id=$id");
+	$post_meta_infos = $wpdb->get_results( $wpdb->prepare( "SELECT meta_key, meta_value FROM {$wpdb->postmeta} WHERE post_id = %d", $id ) );
 
-	if (count($post_meta_infos)!=0) {
-		$sql_query = "INSERT INTO $wpdb->postmeta (post_id, meta_key, meta_value) ";
-		foreach ($post_meta_infos as $meta_info) {
-			$meta_key = $meta_info->meta_key;
-			$meta_value = addslashes($meta_info->meta_value);
-			$sql_query_sel[]= "SELECT $new_id, '$meta_key', '$meta_value'";
+	if ( count( $post_meta_infos ) ) {
+		$sql_query     = "INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value) ";
+		$sql_query_sel = array();
+		foreach ( $post_meta_infos as $meta_info ) {
+			$sql_query_sel[] = $wpdb->prepare(
+				"SELECT %d, %s, %s",
+				$new_id,
+				$meta_info->meta_key,
+				$meta_info->meta_value
+			);
 		}
-		$sql_query.= implode(" UNION ALL ", $sql_query_sel);
-		$wpdb->query($sql_query);
+		$sql_query .= implode( " UNION ALL ", $sql_query_sel );
+		$wpdb->query( $sql_query );
 	}
 }

--- a/duplicate.php
+++ b/duplicate.php
@@ -29,6 +29,7 @@ function edd_duplicate_product() {
 		wp_die( __( 'Product creation failed, could not find original product:', 'edd' ) . ' ' . $id );
 	}
 }
+add_action( 'admin_action_duplicate_product', 'edd_duplicate_product' );
 
 /**
  * Gets a product from the database.

--- a/duplicate.php
+++ b/duplicate.php
@@ -10,7 +10,7 @@ function edd_duplicate_product() {
 	}
 
 	if ( empty( $id ) || ( isset( $_REQUEST['action'] ) && 'duplicate_post_save_as_new_page' === $_REQUEST['action'] ) ) {
-		wp_die( __( 'No product to duplicate has been supplied!', 'edd' ) );
+		wp_die( __( 'No product to duplicate has been supplied!', 'edd-duplicate-downloads' ) );
 	}
 
 	check_admin_referer( 'edd-duplicate-product_' . $id );
@@ -26,7 +26,7 @@ function edd_duplicate_product() {
 		wp_safe_redirect( admin_url( 'post.php?action=edit&post=' . $new_id ) );
 		exit;
 	} else {
-		wp_die( __( 'Product creation failed, could not find original product:', 'edd' ) . ' ' . $id );
+		wp_die( __( 'Product creation failed, could not find original product:', 'edd-duplicate-downloads' ) . ' ' . $id );
 	}
 }
 add_action( 'admin_action_duplicate_product', 'edd_duplicate_product' );
@@ -66,7 +66,7 @@ function edd_create_duplicate_from_product( $post, $parent = 0, $post_status = '
 	} else {
 		$post_parent = $post->post_parent;
 		$post_status = $post_status ? $post_status : 'draft';
-		$suffix      = ' ' . __( "(Copy)", 'edd' );
+		$suffix      = ' ' . __( "(Copy)", 'edd-duplicate-downloads' );
 	}
 
 	$new_post_type         = $post->post_type;

--- a/easy-digital-downloads-duplicate-downloads.php
+++ b/easy-digital-downloads-duplicate-downloads.php
@@ -6,7 +6,7 @@
  * Version: 1.0.1
  * Author: Sandhills Development, LLC
  * Author URI: https://sandhillsdev.com
- * Text Domain: duplicate_downloads
+ * Text Domain: edd-duplicate-downloads
  */
 function edd_dd_wp() {
 	if ( class_exists( 'Easy_Digital_Downloads' ) ) {
@@ -20,3 +20,13 @@ function edd_dd_wp() {
 	}
 }
 add_action( 'plugins_loaded', 'edd_dd_wp' );
+
+/**
+ * Loads the plugin textdomain.
+ *
+ * @since 1.0.2
+ */
+function edd_dd_translate() {
+  load_plugin_textdomain( 'edd-duplicate-downloads', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+}
+add_action( 'init', 'edd_dd_translate' );

--- a/easy-digital-downloads-duplicate-downloads.php
+++ b/easy-digital-downloads-duplicate-downloads.php
@@ -3,9 +3,9 @@
  * Plugin Name: Easy Digital Downloads - Duplicate Downloads
  * Plugin URI: https://easydigitaldownloads.com/downloads/duplicate-download/
  * Description: Duplicates EDD Downloads
- * Version: 1.0.1
- * Author: Sandhills Development, LLC
- * Author URI: https://sandhillsdev.com
+ * Version: 1.0.2
+ * Author: Easy Digital Downloads
+ * Author URI: https://easydigitaldownloads.com/
  * Text Domain: edd-duplicate-downloads
  */
 function edd_dd_wp() {
@@ -16,7 +16,7 @@ function edd_dd_wp() {
 			require_once( dirname( __FILE__ ) . '/admin.php' );
 		}
 
-		$license = new EDD_License( __FILE__, 'Duplicate Downloads', '1.0.1', 'Sandhills Development, LLC', null, null, 74950 );
+		$license = new EDD_License( __FILE__, 'Duplicate Downloads', '1.0.2', 'Easy Digital Downloads', null, null, 74950 );
 	}
 }
 add_action( 'plugins_loaded', 'edd_dd_wp' );

--- a/easy-digital-downloads-duplicate-downloads.php
+++ b/easy-digital-downloads-duplicate-downloads.php
@@ -1,14 +1,13 @@
 <?php
-/*
-Plugin Name: Easy Digital Downloads - Duplicate Downloads
-Plugin URI: https://easydigitaldownloads.com/downloads/duplicate-download/
-Description: Duplicates EDD Downloads
-Version: 1.0.1
-Author: Easy Digital Downloads
-Author URI: https://easydigitaldownloads.com
-Text Domain: duplicate_downloads
+/**
+ * Plugin Name: Easy Digital Downloads - Duplicate Downloads
+ * Plugin URI: https://easydigitaldownloads.com/downloads/duplicate-download/
+ * Description: Duplicates EDD Downloads
+ * Version: 1.0.1
+ * Author: Sandhills Development, LLC
+ * Author URI: https://sandhillsdev.com
+ * Text Domain: duplicate_downloads
  */
-
 function edd_dd_wp() {
 	if ( class_exists( 'Easy_Digital_Downloads' ) ) {
 		require_once( dirname( __FILE__ ) . '/duplicate.php' );
@@ -17,7 +16,7 @@ function edd_dd_wp() {
 			require_once( dirname( __FILE__ ) . '/admin.php' );
 		}
 
-		$license = new EDD_License( __FILE__, 'Duplicate Downloads', '1.0.1', 'EDD Team' );
+		$license = new EDD_License( __FILE__, 'Duplicate Downloads', '1.0.1', 'Sandhills Development, LLC', null, null, 74950 );
 	}
 }
-add_action('plugins_loaded','edd_dd_wp');
+add_action( 'plugins_loaded', 'edd_dd_wp' );

--- a/languages/edd-duplicate-downloads.pot
+++ b/languages/edd-duplicate-downloads.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2021 Sandhills Development, LLC
+# Copyright (C) 2021 Easy Digital Downloads
 # This file is distributed under the same license as the Easy Digital Downloads - Duplicate Downloads plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Digital Downloads - Duplicate Downloads 1.0.1\n"
+"Project-Id-Version: Easy Digital Downloads - Duplicate Downloads 1.0.2\n"
 "Report-Msgid-Bugs-To: https://easydigitaldownloads.com/support\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-09-27T10:24:29+01:00\n"
+"POT-Creation-Date: 2021-09-27T13:05:51+01:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: edd-duplicate-downloads\n"
@@ -27,11 +27,11 @@ msgid "Duplicates EDD Downloads"
 msgstr ""
 
 #. Author of the plugin
-msgid "Sandhills Development, LLC"
+msgid "Easy Digital Downloads"
 msgstr ""
 
 #. Author URI of the plugin
-msgid "https://sandhillsdev.com"
+msgid "https://easydigitaldownloads.com/"
 msgstr ""
 
 #: admin.php:18

--- a/languages/edd-duplicate-downloads.pot
+++ b/languages/edd-duplicate-downloads.pot
@@ -1,0 +1,55 @@
+# Copyright (C) 2021 Sandhills Development, LLC
+# This file is distributed under the same license as the Easy Digital Downloads - Duplicate Downloads plugin.
+msgid ""
+msgstr ""
+"Project-Id-Version: Easy Digital Downloads - Duplicate Downloads 1.0.1\n"
+"Report-Msgid-Bugs-To: https://easydigitaldownloads.com/support\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2021-09-27T10:24:29+01:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.5.0\n"
+"X-Domain: edd-duplicate-downloads\n"
+
+#. Plugin Name of the plugin
+msgid "Easy Digital Downloads - Duplicate Downloads"
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "https://easydigitaldownloads.com/downloads/duplicate-download/"
+msgstr ""
+
+#. Description of the plugin
+msgid "Duplicates EDD Downloads"
+msgstr ""
+
+#. Author of the plugin
+msgid "Sandhills Development, LLC"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://sandhillsdev.com"
+msgstr ""
+
+#: admin.php:18
+msgid "Duplicate"
+msgstr ""
+
+#: admin.php:45
+msgid "Duplicate Me!"
+msgstr ""
+
+#: duplicate.php:13
+msgid "No product to duplicate has been supplied!"
+msgstr ""
+
+#: duplicate.php:29
+msgid "Product creation failed, could not find original product:"
+msgstr ""
+
+#: duplicate.php:69
+msgid "(Copy)"
+msgstr ""

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "build": "npm run i18n",
+    "dev": "cross-env NODE_ENV=production wp-scripts start",
+    "i18n": "wp i18n make-pot . languages/edd-duplicate-downloads.pot --domain=edd-duplicate-downloads --headers='{\"Report-Msgid-Bugs-To\": \"https://easydigitaldownloads.com/support\"}'"
+  }
+}


### PR DESCRIPTION
Milestone: https://github.com/easydigitaldownloads/edd-duplicate-downloads/milestone/2?closed=1

| Issue # | Description |
|---------|-------------|
| #17 | Add translation support / .pot generation |
| #13 | Unnecessary including of `duplicate.php` in `admin.php`  |
| #12 | Verify that there is download to duplicate |
| #11 | Data should be sanitized before it's used |
| #9 | Update author/license |
